### PR TITLE
main.go: create versioning scheme for api

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func logMiddleware(handler http.HandlerFunc) http.HandlerFunc {
 }
 
 // main handler for data collected by pinger
-func dataHandler(w http.ResponseWriter, r *http.Request) {
+func dataHandlerV1(w http.ResponseWriter, r *http.Request) {
 
 	// connect to MongoDB when running test
 	if collectionsPtr == nil {
@@ -238,8 +238,8 @@ func main() {
 		log.Printf("Listening on %s", listenAddress)
 	}
 
-	// Map `/` to our dataHandler and wrap it in the log middleware
-	http.Handle("/", logMiddleware(http.HandlerFunc(dataHandler)))
+	// Map `/v1` to our dataHandlerV1 and wrap it in the log middleware
+	http.Handle("/v1", logMiddleware(http.HandlerFunc(dataHandlerV1)))
 
 	// Run forever on all interfaces on port 5000
 	log.Fatal(http.ListenAndServe(listenAddress, nil))

--- a/main_test.go
+++ b/main_test.go
@@ -307,14 +307,14 @@ func TestDataHandlerSuccess(t *testing.T) {
 			}
 		}
 	}`
-	req, err := http.NewRequest("POST", "/", strings.NewReader(body))
+	req, err := http.NewRequest("POST", "/v1", strings.NewReader(body))
 	req.Header.Set("Content-type", "application/json")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(dataHandler)
+	handler := http.HandlerFunc(dataHandlerV1)
 
 	handler.ServeHTTP(rr, req)
 	if status := rr.Code; status != http.StatusOK {


### PR DESCRIPTION
Initializes an API versioning in order to eliminate fields
or restructure resource representations.

Reference: https://kubernetes.io/docs/reference/using-api/api-overview/#api-versioning
Related: https://github.com/zonggen/fcos-pinger-backend/issues/2
Signed-off-by: Allen Bai <abai@redhat.com>